### PR TITLE
Fix Issue in dark mode.

### DIFF
--- a/resources/views/livewire/translation-edit-form.blade.php
+++ b/resources/views/livewire/translation-edit-form.blade.php
@@ -64,7 +64,7 @@
                         <input
                             wire:model.defer="translations.{{ $locale }}"
                             class="{{
-                                'block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70 border-gray-300' .
+                                'block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70 border-gray-300 ' .
                                 (config('forms.dark_mode') ? 'dark:bg-gray-700 dark:text-white dark:focus:border-primary-500' : null)
                             }}"
                             id="{{ $id }}"


### PR DESCRIPTION
When on dark mode... the class `dark:bg-gray-700` concatenates with `border-gray-300` so what happens is that the the class the is created when using dark mode is `border-gray-300dark:bg-gray-700` to fix this, we add an extra space before concatenation...