### PR TITLE
Customizable icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ You can choose to exclude specific groups of translations from appearing in Fila
 ],
 ```
 
-### Icon
+### Navigation Icon
 
 You can customize the navigation icon by configuring the `navigation-icon` variable
 ```

--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ You can choose to exclude specific groups of translations from appearing in Fila
 ],
 ```
 
+### Icon
+
+You can customize the navigation icon by configuring the `navigation-icon` variable
+```
+'navigation_icon' => 'heroicon-o-language',
+```
+
 ## Usage
 
 The library creates a new directory for the new translations, see [Laravel Chained Translator](https://github.com/statikbe/laravel-chained-translator).

--- a/config/filament-translation-manager.php
+++ b/config/filament-translation-manager.php
@@ -72,4 +72,19 @@ return [
         'gate' => null,
         'sort' => null,
     ],
+
+    /*
+     |--------------------------------------------------------------------------
+     | Navigation Icon
+     |--------------------------------------------------------------------------
+     |
+     | You can specify the navigation icon.
+     | Accepts string value according to Heroicons documentation.
+     | (visit: https://heroicons.com/)
+     | Default: 'heroicon-o-language'
+     | For null value, the icon will be hidden.
+     |
+     */
+
+    'navigation_icon' => 'heroicon-o-language',
 ];

--- a/config/filament-translation-manager.php
+++ b/config/filament-translation-manager.php
@@ -79,8 +79,7 @@ return [
      |--------------------------------------------------------------------------
      |
      | You can specify the navigation icon.
-     | Accepts string value according to Heroicons documentation.
-     | (visit: https://heroicons.com/)
+     | (visit: https://blade-ui-kit.com/blade-icons?set=1#search)
      | Default: 'heroicon-o-language'
      | For null value, the icon will be hidden.
      |

--- a/src/Pages/TranslationManagerPage.php
+++ b/src/Pages/TranslationManagerPage.php
@@ -21,8 +21,6 @@ class TranslationManagerPage extends Page
      */
     const PAGE_LIMIT = 20;
 
-    protected static ?string $navigationIcon = null;
-
     private ChainedTranslationManager $chainedTranslationManager;
 
     public array $groups;
@@ -89,6 +87,11 @@ class TranslationManagerPage extends Page
         return trans('filament-translation-manager::messages.title');
     }
 
+    public static function getNavigationIcon(): ?string
+    {
+        return config('filament-translation-manager.navigation_icon');
+    }
+
     public function getTitle(): string
     {
         return trans('filament-translation-manager::messages.title');
@@ -110,7 +113,6 @@ class TranslationManagerPage extends Page
 
         $this->locales = $this->getLocalesData();
         $this->selectedLocales = $this->locales;
-        static::$navigationIcon = config('filament-translation-manager.navigation_icon') ?? null;
 
         $this->filterTranslations();
     }

--- a/src/Pages/TranslationManagerPage.php
+++ b/src/Pages/TranslationManagerPage.php
@@ -21,7 +21,7 @@ class TranslationManagerPage extends Page
      */
     const PAGE_LIMIT = 20;
 
-    protected static ?string $navigationIcon = 'heroicon-o-language';
+    protected static ?string $navigationIcon;
 
     private ChainedTranslationManager $chainedTranslationManager;
 
@@ -110,6 +110,7 @@ class TranslationManagerPage extends Page
 
         $this->locales = $this->getLocalesData();
         $this->selectedLocales = $this->locales;
+        static::$navigationIcon = config('filament-translation-manager.navigation_icon') ?? null;
 
         $this->filterTranslations();
     }
@@ -138,10 +139,10 @@ class TranslationManagerPage extends Page
 
         //transform to data structure necessary for frontend
         foreach ($translations as $key => $translation) {
-            $dataKey = $group.'.'.$key;
-            if (! array_key_exists($dataKey, $data)) {
+            $dataKey = $group . '.' . $key;
+            if (!array_key_exists($dataKey, $data)) {
                 $data[$dataKey] = [
-                    'title' => $group.' - '.$key,
+                    'title' => $group . ' - ' . $key,
                     'type' => 'group',
                     'group' => $group,
                     'translation_key' => $key,
@@ -222,7 +223,7 @@ class TranslationManagerPage extends Page
             });
         }
 
-        if (! empty($this->selectedGroups)) {
+        if (!empty($this->selectedGroups)) {
             $filteredTranslations = $filteredTranslations->filter(function ($translationItem, $key) {
                 return in_array($translationItem['group'], $this->selectedGroups, true);
             });
@@ -255,7 +256,7 @@ class TranslationManagerPage extends Page
 
     private function getChainedTranslationManager(): ChainedTranslationManager
     {
-        if (! isset($this->chainedTranslationManager)) {
+        if (!isset($this->chainedTranslationManager)) {
             $this->chainedTranslationManager = app(ChainedTranslationManager::class);
         }
 
@@ -304,9 +305,9 @@ class TranslationManagerPage extends Page
         $oldMissing = $this->checkIfTranslationMissing($initialTranslations, $this->getFilteredLocales());
         $newMissing = $this->checkIfTranslationMissing($newTranslation, $this->getFilteredLocales());
 
-        if ($oldMissing && ! $newMissing) {
+        if ($oldMissing && !$newMissing) {
             $this->totalMissingFilteredTranslations--;
-        } elseif (! $oldMissing && $newMissing) {
+        } elseif (!$oldMissing && $newMissing) {
             $this->totalMissingFilteredTranslations++;
         }
     }
@@ -332,7 +333,7 @@ class TranslationManagerPage extends Page
 
     private function getFilteredLocales(): array
     {
-        return ! empty($this->selectedLocales) ? $this->selectedLocales : $this->locales;
+        return !empty($this->selectedLocales) ? $this->selectedLocales : $this->locales;
     }
 
     public static function getNavigationSort(): ?int

--- a/src/Pages/TranslationManagerPage.php
+++ b/src/Pages/TranslationManagerPage.php
@@ -89,7 +89,9 @@ class TranslationManagerPage extends Page
 
     public static function getNavigationIcon(): ?string
     {
-        return config('filament-translation-manager.navigation_icon');
+        return config()->has('filament-translation-manager.navigation_icon')
+            ? config('filament-translation-manager.navigation_icon')
+            : 'heroicon-o-language';
     }
 
     public function getTitle(): string

--- a/src/Pages/TranslationManagerPage.php
+++ b/src/Pages/TranslationManagerPage.php
@@ -21,7 +21,7 @@ class TranslationManagerPage extends Page
      */
     const PAGE_LIMIT = 20;
 
-    protected static ?string $navigationIcon;
+    protected static ?string $navigationIcon = null;
 
     private ChainedTranslationManager $chainedTranslationManager;
 


### PR DESCRIPTION
This pull request introduces flexibility on navigation icon.
Default is still `heroicon-o-language`
`navigation_icon => heroicon-o-language` is added in `filament-translation-manager` config file.
This will allow to customize the navigation icon when config file is published.