### PR TITLE
Fix conflict with phpunit 11 & collision 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,15 +29,15 @@
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.0",
+        "nunomaduro/collision": "^7.0||^8.0",
         "nunomaduro/larastan": "^2.4",
         "orchestra/testbench": "^8.0",
-        "pestphp/pest": "^2.x-dev",
-        "pestphp/pest-plugin-laravel": "2.x-dev",
+        "pestphp/pest": "^2.0",
+        "pestphp/pest-plugin-laravel": "^2.0",
         "phpstan/extension-installer": "^1.2",
         "phpstan/phpstan-deprecation-rules": "^1.1",
         "phpstan/phpstan-phpunit": "^1.3",
-        "phpunit/phpunit": "^10.0"
+        "phpunit/phpunit": "^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
### Description
Allow phpunit 11 & collision 8

### Reason for this change

I upgraded my codebase to laravel 11 recently and cannot install this package. I ended up having to do something like phpunit : 10|^11 on my laravel codebase because I'm using phpunit 11 & ur package is using phpunit 10 but I shouldn't need to do that

If u look at laravel/framework composer.json u can also see that phpunit 11 is allowed

![CleanShot 2024-03-21 at 12 42 47](https://github.com/statikbe/laravel-filament-chained-translation-manager/assets/679513/abfecba2-5d3c-4d76-81b7-992471c1adfd)
