### PR TITLE
Added a button to the editor to toggle multi-line mode 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ There is also a [Laravel Nova Chained Translation Manager](https://github.com/st
 -   Filter translations for specific groups and languages.
 -   Only show keys with missing translations.
 -   Shows statistics of how many fields are completely translated.
+-   :sparkles: Multi-line translation strings support: toggle between text input and text area.
 
 This tool does not provide features to add new translation keys, because our target users are translators and
 content managers, and we want to avoid that they add unnecessary translation keys.

--- a/resources/lang/ar/messages.php
+++ b/resources/lang/ar/messages.php
@@ -16,4 +16,6 @@ return [
     'filter_results' => 'تم تصفية :filtered من :total ترجمة.',
     'filter_results_missing_translations' => ':missing لا توجد لها ترجمة (:percent%).',
     'saved_translation' => 'تم حفظ الترجمة',
+    'cancel_translation_btn' => 'إلغاء الترجمة',
+    'toggle_multi_line_btn' => 'تبديل وضع الأسطر المتعددة',
 ];

--- a/resources/lang/cs/messages.php
+++ b/resources/lang/cs/messages.php
@@ -16,4 +16,6 @@ return [
     'filter_results' => 'Vyfiltrováno :filtered z :total překladů.',
     'filter_results_missing_translations' => ':missing chybějících překladů (:percent%).',
     'saved_translation' => 'Překlad uložen',
+    'cancel_translation_btn' => 'Zrušit překlad',
+    'toggle_multi_line_btn' => 'Přepnout víceřádkový režim',
 ];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -16,4 +16,6 @@ return [
     'filter_results' => 'Filtered out :filtered of :total translations.',
     'filter_results_missing_translations' => ':missing have missing translations (:percent%).',
     'saved_translation' => 'Translation saved',
+    'cancel_translation_btn' => 'Cancel translation',
+    'toggle_multi_line_btn' => 'Toggle multi-line mode',
 ];

--- a/resources/lang/es/messages.php
+++ b/resources/lang/es/messages.php
@@ -16,4 +16,6 @@ return [
     'filter_results' => 'Se filtraron :filtered de :total traducciones.',
     'filter_results_missing_translations' => ':missing tienen traducciones faltantes (:percent%).',
     'saved_translation' => 'Traducción guardada',
+    'cancel_translation_btn' => 'Cancelar traducción',
+    'toggle_multi_line_btn' => 'Alternar modo multilínea',
 ];

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -16,4 +16,6 @@ return [
     'filter_results' => ':filtered éléments filtrés sur :total traductions.',
     'filter_results_missing_translations' => ':missing éléments n\'ont pas de traduction (:percent%).',
     'saved_translation' => 'Traduction sauvegardée',
+    'cancel_translation_btn' => 'Annuler la traduction',
+    'toggle_multi_line_btn' => 'Basculer en mode multiligne',
 ];

--- a/resources/lang/nl/messages.php
+++ b/resources/lang/nl/messages.php
@@ -16,4 +16,6 @@ return [
     'filter_results' => ':filtered gefilterd uit totaal :total vertalingen.',
     'filter_results_missing_translations' => ':missing hebben missende vertalingen (:percent%).',
     'saved_translation' => 'Vertaling opgeslagen',
+    'cancel_translation_btn' => 'Annuleer vertaling',
+    'toggle_multi_line_btn' => 'Verander meerregelige modus',
 ];

--- a/resources/lang/sk/messages.php
+++ b/resources/lang/sk/messages.php
@@ -16,4 +16,6 @@ return [
     'filter_results' => 'Vyfiltrované :filtered z :total prekladov.',
     'filter_results_missing_translations' => ':missing má chýbajúce preklady (:percent%).',
     'saved_translation' => 'Preklad uložený',
+    'cancel_translation_btn' => 'Zrušiť preklad',
+    'toggle_multi_line_btn' => 'Prepnúť viacriadkový režim',
 ];

--- a/resources/views/livewire/translation-edit-form.blade.php
+++ b/resources/views/livewire/translation-edit-form.blade.php
@@ -9,22 +9,27 @@
                 class="flex items-center"
                 x-data="{
                     editing: false,
-                    openForm(){
+                    multiLineMode: {{ substr_count($translations[$locale] ?? '', "\n") > 0 ? 'true' : 'false' }},
+                    openForm() {
                         $dispatch('close-forms');
                         this.editing = true;
                         $nextTick(() => {
                             setTimeout(() => {
-                                $refs.input.focus();
+                                if (this.multiLineMode) {
+                                    $refs.multilineInput.focus();
+                                } else {
+                                    $refs.input.focus();
+                                }
                             }, 50); //Adding a small delay makes this way more consistent
                         });
                     },
-                    closeWithSave(){
+                    closeWithSave() {
                         if (this.editing){
                             this.closeEdit();
                             $wire.save(this.locale);
                         }
                     },
-                    closeWithCancel(){
+                    closeWithCancel() {
                         if (this.editing){
                             this.closeEdit();
                             $wire.cancel();
@@ -33,7 +38,10 @@
                     closeEdit() {
                         this.editing = false;
                     },
-                    locale: '{{ $locale }}'
+                    toggleMultiLine() {
+                        this.multiLineMode = !this.multiLineMode;
+                    },
+                    locale: '{{ $locale }}',
                 }"
                 @click.outside="closeWithSave"
                 @close-forms.window="closeWithSave()"
@@ -60,21 +68,46 @@
                 </x-filament::link>
                 <div
                     class="w-full flex items-center space-x-2"
-                    x-show="editing"
-                >
+                    x-show="editing">
                     <form @submit.prevent="closeWithSave" class="w-full">
                         <input
                             wire:model.defer="translations.{{ $locale }}"
-                            class="{{
-                                'block w-full transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70 border-gray-300 dark:bg-gray-700 dark:text-white dark:focus:border-primary-500 '
-                            }}"
+                            class="block w-full p-2 transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70 border-gray-300 dark:bg-gray-700 dark:text-white dark:focus:border-primary-500"
                             id="{{ $id }}"
                             type="text"
                             x-ref="input"
+                            x-show="!multiLineMode"
+                            x-bind:disabled="multiLineMode"
                         >
+                        <textarea
+                            wire:model.defer="translations.{{ $locale }}"
+                            class="block w-full p-2 transition duration-75 rounded-lg shadow-sm focus:border-primary-500 focus:ring-1 focus:ring-inset focus:ring-primary-500 disabled:opacity-70 border-gray-300 dark:bg-gray-700 dark:text-white dark:focus:border-primary-500"
+                            id="{{ $id }}"
+                            rows="3"
+                            x-ref="multilineInput"
+                            x-show="multiLineMode"
+                            x-bind:disabled="!multiLineMode"></textarea>
                     </form>
                     <div class="flex items-center align-center">
-                        <button @click="closeWithCancel">
+                        <button @click="toggleMultiLine"
+                                title="@lang('filament-translation-manager::messages.toggle_multi_line_btn')"
+                                aria-label="@lang('filament-translation-manager::messages.toggle_multi_line_btn')">
+                            <x-filament::icon
+                                x-show="!multiLineMode"
+                                alias="filament-chained-translation-manager::enable-multi-line"
+                                icon="heroicon-o-bars-arrow-down"
+                                class="w-5 h-5 text-primary-500"/>
+                            <x-filament::icon
+                                x-show="multiLineMode"
+                                alias="filament-chained-translation-manager::disable-multi-line"
+                                icon="heroicon-o-bars-arrow-up"
+                                class="w-5 h-5 text-primary-500"/>
+                        </button>
+                    </div>
+                    <div class="flex items-center align-center">
+                        <button @click="closeWithCancel"
+                                title="@lang('filament-translation-manager::messages.cancel_translation_btn')"
+                                aria-label="@lang('filament-translation-manager::messages.cancel_translation_btn')">
                             <x-filament::icon
                                 alias="filament-chained-translation-manager::cancel-translation"
                                 icon="heroicon-o-x-mark"


### PR DESCRIPTION
### Description
Added a button to the editor to toggle multi-line mode by showing a textarea or input + aria-label/title on the buttons + translations

### Reason for this change
Support multi-line translations.