### PR TITLE
Remove static from $view in the widget

### DIFF
--- a/src/Widgets/TranslationStatusWidget.php
+++ b/src/Widgets/TranslationStatusWidget.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Gate;
 
 class TranslationStatusWidget extends Widget
 {
-    protected static string $view = 'filament-translation-manager::widgets.translation-status';
+    protected string $view = 'filament-translation-manager::widgets.translation-status';
 
     public static function getSort(): int
     {


### PR DESCRIPTION
Fix this fatal error:

PHP Fatal error:  Cannot redeclare non static Filament\Widgets\Widget::$view as static Statikbe\FilamentTranslationManager\Widgets\TranslationStatusWidget::$view in vendor/statikbe/laravel-filament-chained-translation-manager/src/Widgets/TranslationStatusWidget.php on line 8

### Description


### Reason for this change