### PR TITLE
Fixing translationKey name mismatch

### DIFF
--- a/resources/views/pages/translation-manager-page.blade.php
+++ b/resources/views/pages/translation-manager-page.blade.php
@@ -40,7 +40,7 @@
         <livewire:translation-edit-form
             wire:key="{{ $translation['title'] }}.{{ implode('-', $selectedLocales) }}"
             :group="$translation['group']"
-            :translation_key="$translation['translation_key']"
+            :translationKey="$translation['translation_key']"
             :translations="$translation['translations']"
             :locales="$selectedLocales"
         />


### PR DESCRIPTION
Fix for the following error

<img width="1275" height="1061" alt="Bildschirmfoto 2026-03-19 um 10 58 27" src="https://github.com/user-attachments/assets/9979ad68-2b58-472b-b2f8-0545bcda8a9a" />
