### PR TITLE
fix(TranslationEditForm): add default values to typed properties

### DIFF
--- a/resources/views/pages/translation-manager-page.blade.php
+++ b/resources/views/pages/translation-manager-page.blade.php
@@ -40,7 +40,7 @@
         <livewire:translation-edit-form
             wire:key="{{ $translation['title'] }}.{{ implode('-', $selectedLocales) }}"
             :group="$translation['group']"
-            :translationKey="$translation['translation_key']"
+            :translation-key="$translation['translation_key']"
             :translations="$translation['translations']"
             :locales="$selectedLocales"
         />

--- a/src/Http/Livewire/TranslationEditForm.php
+++ b/src/Http/Livewire/TranslationEditForm.php
@@ -9,15 +9,15 @@ use Statikbe\LaravelChainedTranslator\ChainedTranslationManager;
 
 class TranslationEditForm extends Component
 {
-    public string $group;
+    public string $group = '';
 
-    public string $translationKey;
+    public string $translationKey = '';
 
-    public array $translations;
+    public array $translations = [];
 
-    public array $initialTranslations;
+    public array $initialTranslations = [];
 
-    public array $locales;
+    public array $locales = [];
 
     /**
      * @const string


### PR DESCRIPTION
This pull request makes minor improvements to the `TranslationEditForm` component by initializing several properties with default values. This helps prevent potential issues with uninitialized variables.

* Initialization of properties: Set default values for `group`, `translationKey`, `translations`, `initialTranslations`, and `locales` in the `TranslationEditForm` class to ensure safer and more predictable behavior. (`src/Http/Livewire/TranslationEditForm.php`)